### PR TITLE
Remove unwanted stdout output.

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -41,33 +41,6 @@
 #include "vmobjects/ObjectFormats.h"
 
 int main(int argc, char** argv) {
-
-    cout << "This is SOM++" << endl;
-
-    if (GC_TYPE == GENERATIONAL)
-        cout << "\tgarbage collector: generational" << endl;
-    else if (GC_TYPE == COPYING)
-        cout << "\tgarbage collector: copying" << endl;
-    else if (GC_TYPE == MARK_SWEEP)
-        cout << "\tgarbage collector: mark-sweep" << endl;
-    else
-        cout << "\tgarbage collector: unknown" << endl;
-
-    if (USE_TAGGING)
-        cout << "\twith tagged integers" << endl;
-    else
-        cout << "\tnot tagging integers" << endl;
-
-    if (CACHE_INTEGER)
-        cout << "\tcaching integers from " << INT_CACHE_MIN_VALUE
-             << " to " << INT_CACHE_MAX_VALUE << endl;
-    else
-        cout << "\tnot caching integers" << endl;
-
-
-    cout << "--------------------------------------" << endl;
-
-
     Universe::Start(argc, argv);
 
     Universe::Quit(ERR_SUCCESS);


### PR DESCRIPTION
Krun uses the output from stdout to build up a results JSON file. So we
want this to be otherwise clean.