### PR TITLE
Remove special-case optimisation of ifTrue: and ifFalse:.

### DIFF
--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -616,79 +616,6 @@ bool Parser::binaryOperand(MethodGenerationContext* mgenc) {
     return super;
 }
 
-void Parser::ifTrueMessage(MethodGenerationContext* mgenc) {
-    size_t false_block_pos = bcGen->EmitJUMP_IF_FALSE(mgenc);
-    if (sym == NewBlock) {
-        inlinedBlock(mgenc);
-    } else {
-        formula(mgenc);
-        VMSymbol* msg = GetUniverse()->SymbolFor("value");
-        mgenc->AddLiteralIfAbsent(msg);
-        bcGen->EmitSEND(mgenc, msg);
-    }
-    
-    size_t after_pos = bcGen->EmitJUMP(mgenc);
-    mgenc->PatchJumpTarget(false_block_pos);
-    
-    if (sym == Keyword) {
-        StdString ifFalse = keyword();
-        assert(ifFalse == "ifFalse:");
-        if (sym == NewBlock) {
-            inlinedBlock(mgenc);
-        } else {
-            formula(mgenc);
-            VMSymbol* msg = GetUniverse()->SymbolFor("value");
-            mgenc->AddLiteralIfAbsent(msg);
-            bcGen->EmitSEND(mgenc, msg);
-        }
-    } else {
-        VMSymbol* global = GetUniverse()->SymbolFor("nil");
-        mgenc->AddLiteralIfAbsent(global);
-        
-        bcGen->EmitPUSHGLOBAL(mgenc, global);
-    }
-    mgenc->PatchJumpTarget(after_pos);
-    
-    assert(sym != Keyword);
-}
-
-void Parser::ifFalseMessage(MethodGenerationContext* mgenc) {
-    size_t false_block_pos = bcGen->EmitJUMP_IF_TRUE(mgenc);
-    if (sym == NewBlock) {
-        inlinedBlock(mgenc);
-    } else {
-        formula(mgenc);
-        VMSymbol* msg = GetUniverse()->SymbolFor("value");
-        mgenc->AddLiteralIfAbsent(msg);
-        bcGen->EmitSEND(mgenc, msg);
-    }
-    
-    size_t after_pos = bcGen->EmitJUMP(mgenc);
-    mgenc->PatchJumpTarget(false_block_pos);
-    
-    if (sym == Keyword) {
-        StdString ifFalse = keyword();
-        assert(ifFalse == "ifTrue:");
-        if (sym == NewBlock) {
-            inlinedBlock(mgenc);
-        } else {
-            formula(mgenc);
-            VMSymbol* msg = GetUniverse()->SymbolFor("value");
-            mgenc->AddLiteralIfAbsent(msg);
-            bcGen->EmitSEND(mgenc, msg);
-        }
-    } else {
-        VMSymbol* global = GetUniverse()->SymbolFor("nil");
-        mgenc->AddLiteralIfAbsent(global);
-        
-        bcGen->EmitPUSHGLOBAL(mgenc, global);
-    }
-    mgenc->PatchJumpTarget(after_pos);
-    
-    assert(sym != Keyword);
-
-}
-
 void Parser::inlinedBlock(MethodGenerationContext* mgenc) {
     expect(NewBlock);
     blockContents(mgenc, true);
@@ -701,14 +628,6 @@ void Parser::inlinedBlock(MethodGenerationContext* mgenc) {
 void Parser::keywordMessage(MethodGenerationContext* mgenc, bool super) {
     StdString kw = keyword();
     
-    // special compilation for ifTrue and ifFalse
-    if (!super && kw == "ifTrue:") {
-        ifTrueMessage(mgenc);
-        return;
-    } else if (!super && kw == "ifFalse:") {
-        ifFalseMessage(mgenc);
-        return;
-    }
     formula(mgenc);
     while (sym == Keyword) {
         kw.append(keyword());


### PR DESCRIPTION
Like some other Smalltalks (but unlike most SOMs), SOMpp treats message sends whose name is "ifTrue:" or "ifFalse:" as if they were boolean calls. When this assumption is incorrect, bad things happen. In my opinion, this is not a safe optimisation, since it's quite easy to write a program where this optimisation causes problems. Since no other SOM that I know of does the same thing, it seems best off to remove it.

Note that this is untested, because I don't have the Krun bits on my machine. @jacob-hughes I'm afraid you'll need to explicitly test this, as I can't :/